### PR TITLE
Added missing end to spec file

### DIFF
--- a/spec/06_patient_spec.rb
+++ b/spec/06_patient_spec.rb
@@ -39,6 +39,7 @@ describe 'Patient' do
       expect(steve.appointments).to include(appointment_one)
       expect(steve.appointments).to include(appointment_two)
     end
+  end
 
   describe '#doctors' do
     it 'has many doctors through appointments' do


### PR DESCRIPTION
Ran into this error, while working with a student: 

> spec/06_patient_spec.rb:55: syntax error, unexpected end-of-input, expecting keyword_end (SyntaxError)

I think it's something new. But it can be tedious to search for the missing 'end'. But we found it to help the next student =D