### PR TITLE
Change Appointment model #new test to match instructions

### DIFF
--- a/spec/05_appointment_spec.rb
+++ b/spec/05_appointment_spec.rb
@@ -15,11 +15,11 @@ describe "Appointment" do
   end
 
   describe "#new" do
-    it "initializes with a patient, doctor, and date" do
+    it "initializes with a date, patient, and doctor" do
       doctor_who = Doctor.new("The Doctor")
       hevydevy = Patient.new("Devin Townsend")
 
-      expect{Appointment.new(hevydevy, doctor_who, "Friday, January 32nd")}.to_not raise_error
+      expect{Appointment.new("Friday, January 32nd", hevydevy, doctor_who)}.to_not raise_error
     end
   end
 


### PR DESCRIPTION
The instructions seem to suggest an order of arguments with which to initialize a Appointment (date, patient, doctor)
![has many objects through lab instructions](https://user-images.githubusercontent.com/19792273/48507513-fdc52580-e800-11e8-8a0c-a64a0aa1dae9.png)

However, when students use this order, tests do not pass:
![date-patient-doctor appt initialize-failing](https://user-images.githubusercontent.com/19792273/48509541-459a7b80-e806-11e8-8403-601d37206d47.png)
![date-patient-doctor doctor class errors](https://user-images.githubusercontent.com/19792273/48509726-b5a90180-e806-11e8-9275-6ba56cbecf21.png)

The tests pass when the #initialize arguments are set in patient-doctor-date order:

![patient-doctor-date appt initialize - passing](https://user-images.githubusercontent.com/19792273/48509601-68c52b00-e806-11e8-9a00-e91f0c355fd3.png)
![patient-doctor-date doctor class - passing tests](https://user-images.githubusercontent.com/19792273/48509743-c2c5f080-e806-11e8-95d5-788b7f9ee58f.png)

Proposing this change to match spec to lab instructions.