### PR TITLE
Added note about order of arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ Now let's move on to our `Doctor`/`Appointment`/`Patient` domain model.
   class variable.
 - A doctor should be initialized with a name and be saved in the `@@all` array.
 - The `Doctor` class needs an instance method, `#new_appointment`, that takes in a
-  date and an instance of the `Patient` class, and creates a new `Appointment`. That
-  `Appointment` should know that it belongs to the doctor
+  date and an instance of the `Patient` class (see Note below), 
+  and creates a new `Appointment`. That `Appointment` should know that it belongs 
+  to the doctor
 - The `Doctor` class needs an instance method, `#appointments`, that iterates
   through all `Appointment`s and finds those belonging to this doctor.
 - The `Doctor` class needs an instance method, `#patients`, that iterates over
@@ -101,8 +102,9 @@ doogie = Doctor.new("Doogie Howser")
   class variable.
 - A patient is instantiated with a name and be saved in the `@@all` array.
 - The `Patient` class needs an instance method, `#new_appointment`, that takes in
-  a date and an instance of the `Doctor` class and creates a new `Appointment`. The
-  `Appointment` should know that it belongs to the patient.
+  a date and an instance of the `Doctor` class (see Note below) 
+  and creates a new `Appointment`. The `Appointment` should know that it belongs 
+  to the patient.
 - The `Patient` class needs an instance method, `#appointments`, that iterates
   through the `Appointment`s array and returns `Appointment`s that belong to the
   patient.
@@ -119,8 +121,9 @@ ferris = Patient.new("Ferris Bueller")
 - The `Appointment` class needs a class variable `@@all` that begins as an empty array.
 - The `Appointment` class needs a class method `.all` that lists each `Appointment`
   in the class variable.
-- An `Appointment` should be initialized with a date (as a string, like `"Monday, August 1st"`), a patient, and a doctor. The `Appointment` should be saved in the
-  `@@all` array.
+- An `Appointment` should be initialized with a date (as a string, like `"Monday, 
+  August 1st"`), a patient, and a doctor (see Note below). The 
+  `Appointment` should be saved in the `@@all` array.
 
 ```ruby
 ferris = Patient.new("Ferris Bueller")
@@ -128,6 +131,8 @@ doogie = Doctor.new("Doogie Howser")
 
 new_appointment = Appointment.new('January 1st, 1989', ferris, doogie)
 ```
+
+**Note:** the tests will be calling your `#new_appointment` methods in your `Doctor` and `Patient` classes, as well as the `#initialize` method in the `Appointment` class. Therefore, in order to pass the tests, you will need to make sure that your method definitions specify the parameters in the order indicated above. 
 
 <p class='util--hide'>View <a href='https://learn.co/lessons/ruby-objects-has-many-through-lab'>Has Many Objects Through Lab</a> on Learn.co and start learning to code for free.</p>
 


### PR DESCRIPTION
AAQ continues to get a lot of students who have argument order errors despite my earlier attempts to clarify the instructions. I have now added a Note to explicitly tell students what they need to do to avoid those problems.