### PR TITLE
emend matcher line 27 of Doctor spec to test for all appointments of a…

### DIFF
--- a/spec/04_doctor_spec.rb
+++ b/spec/04_doctor_spec.rb
@@ -24,6 +24,7 @@ describe 'Doctor' do
       appointment_2 = Appointment.new('Saturday, January 33rd', hevydevy, doctor_smith)
       
       expect(doctor_who.appointments).to include(appointment)
+      expect(doctor_who.appointments).not_to include(appointment_2)
       expect(doctor_smith.appointments).to include(appointment_2)
 
     end


### PR DESCRIPTION
…specific doctor. 

Current test is missing `not_to` matcher and is allowing test to pass for finding all appointments rather than just appointments of a specific doctor.

Added one additional line and matcher to this test to ensure the second set of test data runs and passes under this new criteria.